### PR TITLE
Minor vsColor changes

### DIFF
--- a/VS/Graphics/VS_Color.cpp
+++ b/VS/Graphics/VS_Color.cpp
@@ -221,8 +221,10 @@ vsColor vsInterpolate( float alpha, const vsColor &a, const vsColor &b )
 
 vsColor vsInterpolateHSV( float alpha, const vsColor &a, const vsColor &b )
 {
-	float aHue = a.GetHue();
-	float bHue = b.GetHue();
+	vsColorHSV aHSV(a);
+	vsColorHSV bHSV(b);
+	float aHue = aHSV.h;
+	float bHue = bHSV.h;
 	float hue;
 	if ( fabs(bHue - aHue) < 0.5f )
 	{
@@ -241,9 +243,9 @@ vsColor vsInterpolateHSV( float alpha, const vsColor &a, const vsColor &b )
 		if ( hue < 1.f )
 			hue += 1.f;
 	}
-	float sat = vsInterpolate(alpha, a.GetSaturation(), b.GetSaturation());
-	float val = vsInterpolate(alpha, a.GetValue(), b.GetValue());
-	return vsColor::FromHSV(hue, sat, val);
+	float sat = vsInterpolate(alpha, aHSV.s, bHSV.s);
+	float val = vsInterpolate(alpha, aHSV.v, bHSV.v);
+	return vsColor::FromHSV(hue, sat, val);  // Note: this ignores a and b alpha, and uses new 1.0 alpha
 }
 
 vsColorHSV::vsColorHSV():

--- a/VS/Graphics/VS_Color.h
+++ b/VS/Graphics/VS_Color.h
@@ -59,7 +59,7 @@ class vsColorPacked
 public:
 	uint8_t r, g, b, a;
 
-	vsColorPacked(uint8_t red=0, uint8_t green=0, uint8_t blue=0, uint8_t alpha=1) { r=red; g=green; b=blue; a=alpha; }
+	vsColorPacked(uint8_t red=0, uint8_t green=0, uint8_t blue=0, uint8_t alpha=255) { r=red; g=green; b=blue; a=alpha; }
 	vsColorPacked(const vsColor& c);
 	vsColorPacked(const vsColorHSV& hsv);
 


### PR DESCRIPTION
Alpha for vsColorPacked default constructor should be 255 rather than 1
In vsColor::vsInterpolateHSV, create two temporary vsColorHSV instances, rather than creating them three times each during the calculations.
